### PR TITLE
Fix cta padding

### DIFF
--- a/layouts/partials/alpine.html
+++ b/layouts/partials/alpine.html
@@ -15,17 +15,12 @@
 nav.main-nav a.cta {
 	background: {{ .Site.Params.alpine_accent_background_color }};
 	color: {{ .Site.Params.alpine_accent_text_color }};
-	padding: 6px 14px;
 	border: 2px solid {{ .Site.Params.alpine_accent_text_color }};
-	border-radius: 20px;
-	white-space: nowrap;
-	box-shadow: none;
 }
 
 nav.main-nav a.cta:hover {
 	background: {{ .Site.Params.alpine_hover_background_color }};
 	color: {{ .Site.Params.alpine_accent_text_color }};
-	margin-left: 12px;
 }
 
 </style>

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -81,7 +81,7 @@ nav.main-nav a {
 nav.main-nav a.cta {
 	background: #fff;
 	color: #ee4792;
-	padding: 6px 14px;
+	padding: 6px 14px 4px;
 	border: 2px solid #fcdae9;
 	border-bottom: none;
 	border-radius: 20px;


### PR DESCRIPTION
It seems that the CTA menu link doesn't look balanced in terms of padding. Using 4px for bottom padding seems to fix this.

Additionally, when trying to edit my copy of the theme in [my blog](https://mau.fyi), I noticed the style definitions in `alpine.html` that make sure the custom accent colors are being used also overrides non color-related variables, meaning that any customization done in `style.css` is not used. This is counter-intuitive, as there's no way to change these extra variables in the plugin settings.

**Before**
![Screenshot from 2023-12-28 10-43-31](https://github.com/microdotblog/theme-alpine/assets/844344/6e0d8497-8dff-4521-bdd3-c68e0c129913)

**After**
![Screenshot from 2023-12-28 10-43-47](https://github.com/microdotblog/theme-alpine/assets/844344/83d6c297-0c2a-4dcb-b9c9-508dd2f85af5)

Let me know what you think.

Thanks!
